### PR TITLE
add event 

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -29,4 +29,18 @@ function OutlineButton({ children, callBack }) {
   );
 }
 
-export { Button, OutlineButton };
+function SubmitButton({ css, value = "Submit" }) {
+  return <input type="submit" value={value} className={css} />;
+}
+
+function OutlineSubmitButton({ value }) {
+  const outlineStyle = `bg-transparent hover:bg-gray-700
+                 text-xs text-gray-700 font-semibold hover:text-white
+                 py-1 px-2
+                 border border-gray-700 hover:border-transparent
+                 rounded`;
+
+  return <SubmitButton value={value} css={outlineStyle} />;
+}
+
+export { Button, OutlineButton, SubmitButton, OutlineSubmitButton };

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,9 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-function Button({ children, callBack, css = "" }) {
+function Button({ children, callBack, css = "", value = "", type = "button" }) {
   return (
-    <button onClick={callBack} className={`${css} px-1 focus:outline-none`}>
+    <button
+      onClick={callBack}
+      className={`${css} focus:outline-none`}
+      value={value}
+      type={type}
+    >
       {children}
     </button>
   );
@@ -16,14 +21,29 @@ Button.propTypes = {
 };
 
 function OutlineButton({ children, callBack }) {
-  const outlineStyle = `bg-transparent hover:bg-gray-700
-                 text-xs text-gray-700 font-semibold hover:text-white
+  const outlineStyle = `bg-transparent hover:bg-blue-800
+                 text-xs text-blue-700 font-semibold hover:text-white
                  py-1 px-2
-                 border border-gray-700 hover:border-transparent
-                 rounded`;
+                 border border-blue-700 hover:border-transparent
+                 `;
 
   return (
     <Button callBack={callBack} css={outlineStyle}>
+      {children}
+    </Button>
+  );
+}
+
+function BlueButton({ children, callBack }) {
+  const blueStyle = `
+                 bg-blue-500 hover:bg-blue-700
+                 text-xs text-white font-semibold hover:text-white
+                 py-2 px-4
+                 border hover:border-blue-400
+                 cursor-pointer`;
+
+  return (
+    <Button callBack={callBack} css={blueStyle}>
       {children}
     </Button>
   );
@@ -33,14 +53,33 @@ function SubmitButton({ css, value = "Submit" }) {
   return <input type="submit" value={value} className={css} />;
 }
 
+function BlueSubmitButton({ value }) {
+  const blueStyle = `w-1/3
+                 bg-blue-500 hover:bg-blue-800
+                 text-xs text-white font-semibold hover:text-white
+                 py-2 px-2
+                 border border-blue-700 hover:border-blue-800
+                 cursor-pointer`;
+
+  return <SubmitButton value={value} css={blueStyle} />;
+}
+
 function OutlineSubmitButton({ value }) {
-  const outlineStyle = `bg-transparent hover:bg-gray-700
-                 text-xs text-gray-700 font-semibold hover:text-white
-                 py-1 px-2
-                 border border-gray-700 hover:border-transparent
-                 rounded`;
+  const outlineStyle = `bg-transparent hover:bg-blue-700
+                 text-sm text-blue-700 font-semibold hover:text-white
+                 py-2 px-2
+                 border border-blue-700 hover:border-transparent 
+                 rounded
+                 `;
 
   return <SubmitButton value={value} css={outlineStyle} />;
 }
 
-export { Button, OutlineButton, SubmitButton, OutlineSubmitButton };
+export {
+  Button,
+  OutlineButton,
+  SubmitButton,
+  OutlineSubmitButton,
+  BlueSubmitButton,
+  BlueButton,
+};

--- a/src/CalendarYearTable.js
+++ b/src/CalendarYearTable.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
-import { Modal, ModalStore, ModalContext } from "./Modal";
+import Modal from "./Modal";
 import { range, createCells } from "./utils";
+import { OutlineButton } from "./Button";
 
 dayjs.extend(LocalizedFormat);
 
@@ -11,13 +12,18 @@ function CalendarYearTable({ year }) {
   const monthDays = range(1, 31);
   const columns = range(1, 14);
   const css = { cellBorders: "border border-gray-500" };
-  const events = {
+  const dummyEvents = {
     "2020-04-13": [{ title: "go to the beach" }, { title: "play FF7" }],
     "2020-04-19": [{ title: "confinement" }],
     "2020-05-20": [{ title: "poule au pot" }],
   };
 
+  const [events, setEvents] = useState(dummyEvents);
   const cells = createCells(year, events);
+
+  function addEvent(event) {
+    setEvents({ ...events, ...event });
+  }
 
   return (
     <table className="table-fixed w-full border text-xs bg-white">
@@ -33,7 +39,14 @@ function CalendarYearTable({ year }) {
           ))}
         </tr>
         {monthDays.map((monthDay) => {
-          return <DaysRow days={cells[monthDay]} key={monthDay} css={css} />;
+          return (
+            <DaysRow
+              days={cells[monthDay]}
+              key={monthDay}
+              css={css}
+              onAddEvent={addEvent}
+            />
+          );
         })}
       </tbody>
     </table>
@@ -70,25 +83,28 @@ function MonthsRow({ css }) {
   );
 }
 
-function DaysRow({ days, css }) {
+function DaysRow({ days, css, onAddEvent }) {
   const tdClass = `${css.cellBorders} font-semibold text-center text-gray-700`;
   const monthDay = dayjs(days[0].date).format("D");
+
   return (
-    <ModalStore>
-      <tr>
-        <td className={tdClass}>{monthDay}</td>
-        {days.map((day, id) =>
-          day.hasDate ? (
-            <Modal key={id}>
-              <DayCell date={day.date} events={day.events} css={css} key={id} />
-            </Modal>
-          ) : (
-            <EmptyCell css={css} key={id} />
-          )
-        )}
-        <td className={tdClass}>{monthDay}</td>
-      </tr>
-    </ModalStore>
+    <tr>
+      <td className={tdClass}>{monthDay}</td>
+      {days.map((day, id) =>
+        day.hasDate ? (
+          <DayCell
+            date={day.date}
+            events={day.events}
+            css={css}
+            key={id}
+            onAddEvent={onAddEvent}
+          />
+        ) : (
+          <EmptyCell css={css} key={id} />
+        )
+      )}
+      <td className={tdClass}>{monthDay}</td>
+    </tr>
   );
 }
 
@@ -96,8 +112,9 @@ function EmptyCell({ css }) {
   return <td className={`${css.cellBorders}`}></td>;
 }
 
-function DayCell({ date, events, css }) {
-  const { onShowModal } = useContext(ModalContext);
+function DayCell({ date, events, css, onAddEvent }) {
+  const [showModal, setShowModal] = useState(false);
+  const closeModal = () => setShowModal(false);
 
   const weekday = dayjs(date).format("dddd");
 
@@ -123,12 +140,17 @@ function DayCell({ date, events, css }) {
   const tdStyle = getTDStyle();
 
   return (
-    <td
-      className={`px-2 ${css.cellBorders} ${tdStyle} font-semibold cursor-pointer`}
-      onClick={() => onShowModal(<EventList date={date} events={events} />)}
-    >
-      {weekday[0]}
-    </td>
+    <>
+      <td
+        className={`px-2 ${css.cellBorders} ${tdStyle} font-semibold cursor-pointer`}
+        onClick={() => setShowModal(true)}
+      >
+        {weekday[0]}
+      </td>
+      <Modal showModal={showModal} onCloseModal={closeModal}>
+        <EventList date={date} events={events} onAddEvent={onAddEvent} />
+      </Modal>
+    </>
   );
 }
 
@@ -138,7 +160,13 @@ DayCell.propTypes = {
   css: PropTypes.object,
 };
 
-function EventList({ date, events }) {
+function EventList({ date, events, onAddEvent }) {
+  const addEvent = () => {
+    onAddEvent({
+      [dayjs(date).format("YYYY-MM-DD")]: [{ title: "added event" }],
+    });
+  };
+
   return (
     <div className="mx-2">
       <h2 className="text-xl font-medium text-gray-800 leading-loose border-b-2 border-yellow-600">
@@ -147,8 +175,15 @@ function EventList({ date, events }) {
       <ul className="list-inside list-disc mt-2 text-gray-800">
         {events && events.map((event, idx) => <li key={idx}>{event.title}</li>)}
       </ul>
+      <OutlineButton callBack={addEvent}>Add Event</OutlineButton>
     </div>
   );
 }
+
+EventList.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  events: PropTypes.array,
+  onAddEvent: PropTypes.func.isRequired,
+};
 
 export default CalendarYearTable;

--- a/src/CalendarYearTable.js
+++ b/src/CalendarYearTable.js
@@ -4,8 +4,7 @@ import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import Modal from "./Modal";
 import { range, createCells } from "./utils";
-import { OutlineButton } from "./Button";
-
+import EventList from "./EventList";
 dayjs.extend(LocalizedFormat);
 
 function CalendarYearTable({ year }) {
@@ -13,9 +12,18 @@ function CalendarYearTable({ year }) {
   const columns = range(1, 14);
   const css = { cellBorders: "border border-gray-500" };
   const dummyEvents = {
-    "2020-04-13": [{ title: "go to the beach" }, { title: "play FF7" }],
-    "2020-04-19": [{ title: "confinement" }],
-    "2020-05-20": [{ title: "poule au pot" }],
+    "2020-04-13": [
+      { date: "2020-04-13", time: "15:00", title: "go to the beach" },
+      {
+        date: "2020-04-13",
+        time: "17:00",
+        title: "play FF7 with Ryan and Simon",
+      },
+    ],
+    "2020-04-19": [{ date: "2020-04-19", time: "15:00", title: "confinement" }],
+    "2020-05-20": [
+      { date: "2020-04-20", time: "15:00", title: "poule au pot" },
+    ],
   };
 
   const [events, setEvents] = useState(dummyEvents);
@@ -168,33 +176,6 @@ DayCell.propTypes = {
   date: PropTypes.instanceOf(Date).isRequired,
   events: PropTypes.array,
   css: PropTypes.object,
-};
-
-function EventList({ date, events, onAddEvent }) {
-  const addEvent = () => {
-    onAddEvent({
-      date: dayjs(date).format("YYYY-MM-DD"),
-      title: "added event",
-    });
-  };
-
-  return (
-    <div className="mx-2">
-      <h2 className="text-xl font-medium text-gray-800 leading-loose border-b-2 border-yellow-600">
-        {dayjs(date).format("LL")}
-      </h2>
-      <ul className="list-inside list-disc mt-2 text-gray-800">
-        {events && events.map((event, idx) => <li key={idx}>{event.title}</li>)}
-      </ul>
-      <OutlineButton callBack={addEvent}>Add Event</OutlineButton>
-    </div>
-  );
-}
-
-EventList.propTypes = {
-  date: PropTypes.instanceOf(Date).isRequired,
-  events: PropTypes.array,
-  onAddEvent: PropTypes.func.isRequired,
 };
 
 export default CalendarYearTable;

--- a/src/CalendarYearTable.js
+++ b/src/CalendarYearTable.js
@@ -22,7 +22,17 @@ function CalendarYearTable({ year }) {
   const cells = createCells(year, events);
 
   function addEvent(event) {
-    setEvents({ ...events, ...event });
+    let newEvents;
+    if (events[event.date]) {
+      newEvents = [...events[event.date], event];
+    } else {
+      newEvents = [event];
+    }
+
+    setEvents({
+      ...events,
+      [event.date]: newEvents,
+    });
   }
 
   return (
@@ -163,7 +173,8 @@ DayCell.propTypes = {
 function EventList({ date, events, onAddEvent }) {
   const addEvent = () => {
     onAddEvent({
-      [dayjs(date).format("YYYY-MM-DD")]: [{ title: "added event" }],
+      date: dayjs(date).format("YYYY-MM-DD"),
+      title: "added event",
     });
   };
 

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,18 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
-import { OutlineButton } from "./Button";
-import { useEffect } from "react";
+import { OutlineButton, OutlineSubmitButton } from "./Button";
+import { useEffect, useState, useRef } from "react";
 
 function EventList({ date, events, onAddEvent }) {
-  const addEvent = () => {
-    onAddEvent({
-      date: dayjs(date).format("YYYY-MM-DD"),
-      time: "15:00",
-      title:
-        "this event has a very long title because titles should always be readable even when they span several lines",
-    });
-  };
+  const [displayForm, setDisplayForm] = useState(false);
 
   return (
     <div className="h-full flex flex-col mx-2">
@@ -20,7 +13,10 @@ function EventList({ date, events, onAddEvent }) {
         {dayjs(date).format("LL")}{" "}
       </h2>
       <div className="mt-6">
-        <OutlineButton callBack={addEvent}>Add Event</OutlineButton>
+        <OutlineButton callBack={() => setDisplayForm(true)}>
+          Add Event
+        </OutlineButton>
+        <EventForm date={date} display={displayForm} onAddEvent={onAddEvent} />
       </div>
       <div className="h-auto flex self-stretch mt-6 mb-6 pb-6">
         <ul className="list-inside list-disc text-gray-800">
@@ -48,6 +44,47 @@ function Event({ event }) {
       </div>
       <div className="">{event.title}</div>
     </li>
+  );
+}
+
+function EventForm({ date, display, onAddEvent }) {
+  const titleInput = useRef();
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    onAddEvent({
+      date: dayjs(date).format("YYYY-MM-DD"),
+      time: "15:00",
+      title: titleInput.current.value,
+    });
+  };
+
+  return (
+    <>
+      {display && (
+        <form
+          action=""
+          className="bg-gray-100 mt-4 p-4"
+          onSubmit={handleSubmit}
+        >
+          <div id="form-title" className="pb-2">
+            <h3 className="leading-relaxed text-red-800 font-semibold">
+              New event
+            </h3>
+          </div>
+          <input
+            ref={titleInput}
+            className="bg-white appearance-none border-2 border-gray-400 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-red-200"
+            id="inline-full-name"
+            type="text"
+            defaultValue="Go to the beach"
+          />
+          <div className="mt-2">
+            <OutlineSubmitButton />
+          </div>
+        </form>
+      )}
+    </>
   );
 }
 

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,25 +1,29 @@
 import React from "react";
+import { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
-import { OutlineButton, OutlineSubmitButton } from "./Button";
-import { useEffect, useState, useRef } from "react";
+import { Button, OutlineButton, BlueSubmitButton, BlueButton } from "./Button";
+import { range } from "./utils";
 
 function EventList({ date, events, onAddEvent }) {
   const [displayForm, setDisplayForm] = useState(false);
 
   return (
     <div className="h-full flex flex-col mx-2">
-      <h2 className="block text-xl font-medium text-gray-800 leading-loose border-b-2 border-yellow-600">
+      <h2 className="block text-xl font-medium text-gray-800 leading-loose border-b-2 border-gray-300">
         {dayjs(date).format("LL")}{" "}
       </h2>
       <div className="mt-6">
-        <OutlineButton callBack={() => setDisplayForm(true)}>
-          Add Event
-        </OutlineButton>
-        <EventForm date={date} display={displayForm} onAddEvent={onAddEvent} />
+        <BlueButton callBack={() => setDisplayForm(true)}>Add Event</BlueButton>
+        <EventForm
+          date={date}
+          display={displayForm}
+          onAddEvent={onAddEvent}
+          onClose={() => setDisplayForm(false)}
+        />
       </div>
       <div className="h-auto flex self-stretch mt-6 mb-6 pb-6">
-        <ul className="list-inside list-disc text-gray-800">
+        <ul className="block w-full list-inside list-disc text-gray-800">
           {events &&
             events.map((event, idx) => <Event key={idx} event={event} />)}
         </ul>
@@ -35,11 +39,9 @@ EventList.propTypes = {
 };
 
 function Event({ event }) {
-  useEffect(() => console.log(event));
-
   return (
-    <li className="block w-full flex flex-row h-12 mb-4 hover:bg-gray-200">
-      <div className="border-r-2 border-red-600 font-bold pr-4 mr-4">
+    <li className="block w-full flex flex-row h-auto p-2 mb-2 hover:bg-gray-100 border border-transparent hover:border-gray-300">
+      <div className="border-r-2 border-red-600 h-auto font-bold pr-4 mr-4">
         {event.time}
       </div>
       <div className="">{event.title}</div>
@@ -47,16 +49,43 @@ function Event({ event }) {
   );
 }
 
-function EventForm({ date, display, onAddEvent }) {
+function EventForm({ date, display, onAddEvent, onClose }) {
   const titleInput = useRef();
+
+  const [eventHour, setEventHour] = useState(12);
+  const [eventMinutes, setEventMinutes] = useState(0);
+  const [hourPickerShown, setHourPickerShown] = useState(false);
+  const [minutesPickerShown, setMinutesPickerShown] = useState(false);
+
+  const renderTwoDigits = (int) => (int < 10 ? `0${int}` : `${int}`);
+  const twoDigitsHour = renderTwoDigits(eventHour);
+  const twoDigitsMinutes = renderTwoDigits(eventMinutes);
+
+  const displayTimePickers = () => {
+    setMinutesPickerShown(false);
+    setHourPickerShown(true);
+  };
+
+  const chooseHour = (event) => {
+    setEventHour(event.target.value);
+    setHourPickerShown(false);
+    setMinutesPickerShown(true);
+  };
+
+  const chooseMinutes = (event) => {
+    setEventMinutes(event.target.value);
+    setMinutesPickerShown(false);
+  };
 
   const handleSubmit = (event) => {
     event.preventDefault();
+
     onAddEvent({
       date: dayjs(date).format("YYYY-MM-DD"),
-      time: "15:00",
+      time: `${twoDigitsHour}:${twoDigitsMinutes}`,
       title: titleInput.current.value,
     });
+    onClose();
   };
 
   return (
@@ -64,27 +93,112 @@ function EventForm({ date, display, onAddEvent }) {
       {display && (
         <form
           action=""
-          className="bg-gray-100 mt-4 p-4"
+          className="mt-1 p-4 bg-gray-100 border border-blue-800"
           onSubmit={handleSubmit}
         >
-          <div id="form-title" className="pb-2">
-            <h3 className="leading-relaxed text-red-800 font-semibold">
-              New event
+          <div
+            id="form-title"
+            className="flex items-center justify-between pb-2"
+          >
+            <h3 className="leading-relaxed text-2xl tracking-wider text-blue-700 font-semibold">
+              New Event
             </h3>
+            <OutlineButton callBack={onClose}>✕</OutlineButton>
           </div>
-          <input
-            ref={titleInput}
-            className="bg-white appearance-none border-2 border-gray-400 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-red-200"
-            id="inline-full-name"
-            type="text"
-            defaultValue="Go to the beach"
-          />
           <div className="mt-2">
-            <OutlineSubmitButton />
+            <EventLabel>Title</EventLabel>
+            <input
+              ref={titleInput}
+              className="bg-white appearance-none border-2 border-gray-400 w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-300"
+              type="text"
+              defaultValue="Add a title to your event"
+            />
+          </div>
+          <div className="mt-2">
+            <EventLabel>Start time</EventLabel>
+            <input
+              className="bg-white appearance-none border-2 border-gray-400 w-1/5 py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-300"
+              type="text"
+              value={`${twoDigitsHour}:${twoDigitsMinutes}`}
+              onClick={() => displayTimePickers()}
+              readOnly
+            />
+            <HourPicker
+              eventHour={eventHour}
+              onChooseHour={(event) => chooseHour(event)}
+              display={hourPickerShown}
+            />
+            <MinutesPicker
+              eventHour={eventHour}
+              onChooseMinutes={(event) => chooseMinutes(event)}
+              display={minutesPickerShown}
+            />
+          </div>
+          <div className="mt-2">
+            <BlueSubmitButton />
           </div>
         </form>
       )}
     </>
+  );
+}
+
+function HourPicker({ eventHour, onChooseHour, display }) {
+  const hours_range = range(0, 23);
+
+  return (
+    <>
+      {display && (
+        <RangePicker
+          value={eventHour}
+          callBack={onChooseHour}
+          collection={hours_range}
+        />
+      )}
+    </>
+  );
+}
+
+function MinutesPicker({ eventMinutes, onChooseMinutes, display }) {
+  const minutes = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
+
+  return (
+    <>
+      {display && (
+        <RangePicker
+          value={eventMinutes}
+          callBack={onChooseMinutes}
+          collection={minutes}
+        />
+      )}
+    </>
+  );
+}
+
+function RangePicker({ value, callBack, collection }) {
+  const style = `bg-transparent hover:bg-blue-500
+                 text-sm text-gray-700 font-semibold hover:text-white
+                 py-2 px-2
+                 `;
+  return (
+    <div className="grid grid-cols-6 gap-2 mt-1 bg-white border-2 border-gray-400">
+      {collection.map((item) => (
+        <Button
+          value={item}
+          css={style}
+          callBack={callBack}
+          key={item}
+        >{`${item}`}</Button>
+      ))}
+    </div>
+  );
+}
+
+function EventLabel({ children }) {
+  return (
+    <label className="block w-full leading-relaxed tracking-wider text-blue-700 ">
+      {children}
+    </label>
   );
 }
 

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,0 +1,54 @@
+import React from "react";
+import PropTypes from "prop-types";
+import dayjs from "dayjs";
+import { OutlineButton } from "./Button";
+import { useEffect } from "react";
+
+function EventList({ date, events, onAddEvent }) {
+  const addEvent = () => {
+    onAddEvent({
+      date: dayjs(date).format("YYYY-MM-DD"),
+      time: "15:00",
+      title:
+        "this event has a very long title because titles should always be readable even when they span several lines",
+    });
+  };
+
+  return (
+    <div className="h-full flex flex-col mx-2">
+      <h2 className="block text-xl font-medium text-gray-800 leading-loose border-b-2 border-yellow-600">
+        {dayjs(date).format("LL")}{" "}
+      </h2>
+      <div className="mt-6">
+        <OutlineButton callBack={addEvent}>Add Event</OutlineButton>
+      </div>
+      <div className="h-auto flex self-stretch mt-6 mb-6 pb-6">
+        <ul className="list-inside list-disc text-gray-800">
+          {events &&
+            events.map((event, idx) => <Event key={idx} event={event} />)}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+EventList.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  events: PropTypes.array,
+  onAddEvent: PropTypes.func.isRequired,
+};
+
+function Event({ event }) {
+  useEffect(() => console.log(event));
+
+  return (
+    <li className="block w-full flex flex-row h-12 mb-4 hover:bg-gray-200">
+      <div className="border-r-2 border-red-600 font-bold pr-4 mr-4">
+        {event.time}
+      </div>
+      <div className="">{event.title}</div>
+    </li>
+  );
+}
+
+export default EventList;

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -61,19 +61,27 @@ function EventForm({ date, display, onAddEvent, onClose }) {
   const twoDigitsHour = renderTwoDigits(eventHour);
   const twoDigitsMinutes = renderTwoDigits(eventMinutes);
 
+  const styles = {
+    input: `bg-white appearance-none 
+      border-2 border-gray-400 
+      w-full 
+      py-2 px-4 
+      text-gray-700 leading-tight 
+      focus:outline-none focus:bg-white focus:border-blue-300`,
+  };
   const displayTimePickers = () => {
     setMinutesPickerShown(false);
     setHourPickerShown(true);
   };
 
   const chooseHour = (event) => {
-    setEventHour(event.target.value);
+    setEventHour(Number(event.target.value));
     setHourPickerShown(false);
     setMinutesPickerShown(true);
   };
 
   const chooseMinutes = (event) => {
-    setEventMinutes(event.target.value);
+    setEventMinutes(Number(event.target.value));
     setMinutesPickerShown(false);
   };
 
@@ -109,7 +117,7 @@ function EventForm({ date, display, onAddEvent, onClose }) {
             <EventLabel>Title</EventLabel>
             <input
               ref={titleInput}
-              className="bg-white appearance-none border-2 border-gray-400 w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-300"
+              className={styles.input}
               type="text"
               defaultValue="Add a title to your event"
             />
@@ -117,7 +125,7 @@ function EventForm({ date, display, onAddEvent, onClose }) {
           <div className="mt-2">
             <EventLabel>Start time</EventLabel>
             <input
-              className="bg-white appearance-none border-2 border-gray-400 w-1/5 py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-300"
+              className={styles.input}
               type="text"
               value={`${twoDigitsHour}:${twoDigitsMinutes}`}
               onClick={() => displayTimePickers()}
@@ -129,7 +137,7 @@ function EventForm({ date, display, onAddEvent, onClose }) {
               display={hourPickerShown}
             />
             <MinutesPicker
-              eventHour={eventHour}
+              eventMinutes={eventMinutes}
               onChooseMinutes={(event) => chooseMinutes(event)}
               display={minutesPickerShown}
             />
@@ -143,6 +151,13 @@ function EventForm({ date, display, onAddEvent, onClose }) {
   );
 }
 
+EventForm.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  display: PropTypes.bool.isRequired,
+  onAddEvent: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
 function HourPicker({ eventHour, onChooseHour, display }) {
   const hours_range = range(0, 23);
 
@@ -150,7 +165,7 @@ function HourPicker({ eventHour, onChooseHour, display }) {
     <>
       {display && (
         <RangePicker
-          value={eventHour}
+          selectedItem={eventHour}
           callBack={onChooseHour}
           collection={hours_range}
         />
@@ -166,7 +181,7 @@ function MinutesPicker({ eventMinutes, onChooseMinutes, display }) {
     <>
       {display && (
         <RangePicker
-          value={eventMinutes}
+          selectedItem={eventMinutes}
           callBack={onChooseMinutes}
           collection={minutes}
         />
@@ -175,17 +190,20 @@ function MinutesPicker({ eventMinutes, onChooseMinutes, display }) {
   );
 }
 
-function RangePicker({ value, callBack, collection }) {
+function RangePicker({ selectedItem = "", callBack, collection }) {
   const style = `bg-transparent hover:bg-blue-500
                  text-sm text-gray-700 font-semibold hover:text-white
                  py-2 px-2
                  `;
+
   return (
     <div className="grid grid-cols-6 gap-2 mt-1 bg-white border-2 border-gray-400">
       {collection.map((item) => (
         <Button
           value={item}
-          css={style}
+          css={`
+            ${style} ${item === selectedItem ? "border border-blue-500" : ""}
+          `}
           callBack={callBack}
           key={item}
         >{`${item}`}</Button>
@@ -193,6 +211,12 @@ function RangePicker({ value, callBack, collection }) {
     </div>
   );
 }
+
+RangePicker.propTypes = {
+  selectedItem: PropTypes.number.isRequired,
+  callBack: PropTypes.func.isRequired,
+  collection: PropTypes.array.isRequired,
+};
 
 function EventLabel({ children }) {
   return (

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -20,12 +20,14 @@ function ModalContent({ children, onCloseModal }) {
       className="fixed top-0 left-0 w-screen h-screen flex items-center"
       style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
     >
-      <div className="bg-white top-50 left-50 w-1/3 max-w-lg mx-auto p-2 shadow-md border rounded-lg">
+      <div className="static box-border top-0 right-0 h-screen w-1/2 max-w-xl p-2 bg-white border shadow-md">
         <div className="w-full flex items-center justify-end flex-wrap p-1">
           <OutlineButton callBack={() => onCloseModal()}>✕</OutlineButton>
         </div>
 
-        <div className="mx-2 px-1 pt-1 pb-12">{children}</div>
+        <div className="h-full box-border overflow-auto flex flex-col justify-start mx-2 px-1 pt-1 pb-5">
+          {children}
+        </div>
       </div>
     </aside>,
     document.body

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,42 +1,12 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom";
 import { OutlineButton } from "./Button";
-const ModalContext = React.createContext();
 
-function ModalStore({ children }) {
-  const [isShown, setIsShown] = useState(false);
-  const [modalContent, setModalContent] = useState("default message");
-
-  function openModal(content) {
-    setIsShown(true);
-    setModalContent(content);
-  }
-
-  function closeModal() {
-    setIsShown(false);
-  }
-  return (
-    <ModalContext.Provider
-      value={{
-        isShown: isShown,
-        onShowModal: openModal,
-        onCloseModal: closeModal,
-        modalContent: modalContent,
-      }}
-    >
-      {children}
-    </ModalContext.Provider>
-  );
-}
-
-function Modal({ children }) {
-  const { isShown, onCloseModal, modalContent } = useContext(ModalContext);
-
+function Modal({ children, showModal, onCloseModal }) {
   return (
     <>
-      {children}
-      {isShown ? (
-        <ModalContent content={modalContent} onCloseModal={onCloseModal} />
+      {showModal ? (
+        <ModalContent onCloseModal={onCloseModal}>{children}</ModalContent>
       ) : (
         <React.Fragment />
       )}
@@ -44,21 +14,21 @@ function Modal({ children }) {
   );
 }
 
-function ModalContent({ content, onCloseModal }) {
+function ModalContent({ children, onCloseModal }) {
   return ReactDOM.createPortal(
     <aside
       className="fixed top-0 left-0 w-screen h-screen flex items-center"
-      style={{ backgroundColor: "rgba(0, 0, 0, 0.08)" }}
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
     >
       <div className="bg-white top-50 left-50 w-1/3 max-w-lg mx-auto p-2 shadow-md border rounded-lg">
         <div className="w-full flex items-center justify-end flex-wrap p-1">
-          <OutlineButton callBack={onCloseModal}>✕</OutlineButton>
+          <OutlineButton callBack={() => onCloseModal()}>✕</OutlineButton>
         </div>
 
-        <div className="mx-2 px-1 pt-1 pb-12">{content}</div>
+        <div className="mx-2 px-1 pt-1 pb-12">{children}</div>
       </div>
     </aside>,
     document.body
   );
 }
-export { Modal, ModalStore, ModalContext };
+export default Modal;


### PR DESCRIPTION
This feature is currently unfinished, as there are many things to do in order to make it work.

Since getting the modal and overall component behavior to work well took a while, I decided to create an early PR.

I struggled quite a lot to figure out how to update the modal content when you add a new event from a child component.

It pushed me to read quite a lot about state / props and component rendering.

Here are some key mistakes I made in previous PRs: 
- I created a context to handle Modal State. While it may seem a good idea, since in this calendar I need to instantiate many `<Modal>` components to be able to trigger them, using context meant that updating the state would update the state for each and every `<Modal>` Component, while I needed it only once. 
It resulted in a buggy modal display where the content was always the last one in the list, not the one I clicked on. 
As a result, I rewrote the modal Component in a simpler way: it now uses a simple prop to know if is it open or not, and accepts children.

- I passed the child component with an `onClick` function. As a result, the component was rendered once but not rerendered when I updated information. This is why in the first place I had to dig about state and component behavior. I updated the modal behavior to accept children, which is also a lot clearer.

In this PR, i have several things to do: 

⛑ TODO
- ✅ add events to the current day list. Right now, as a first step, it only overwrites the current day list with one new item.
- ✅ create a proper form to add an event.
