### PR TITLE
Improve events list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
       href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css"
       rel="stylesheet"
     />
+    <link href="https://css.gg/css" rel="stylesheet" />
     <title>React App</title>
   </head>
   <body>

--- a/src/Button.js
+++ b/src/Button.js
@@ -34,6 +34,22 @@ function OutlineButton({ children, callBack }) {
   );
 }
 
+function HeaderButton({ children, callBack }) {
+  const style = `flex flex-row
+                 min-h-full
+                 bg-blue-100 hover:bg-blue-700
+                 text-base text-blue-800 font-semibold hover:text-white
+                 py-2 px-4
+                 border-r-2 border-l-2 hover:border-blue-700
+                 cursor-pointer`;
+
+  return (
+    <Button callBack={callBack} css={style}>
+      {children}
+    </Button>
+  );
+}
+
 function BlueButton({ children, callBack }) {
   const blueStyle = `
                  bg-blue-500 hover:bg-blue-700
@@ -82,4 +98,5 @@ export {
   OutlineSubmitButton,
   BlueSubmitButton,
   BlueButton,
+  HeaderButton,
 };

--- a/src/Button.js
+++ b/src/Button.js
@@ -34,22 +34,6 @@ function OutlineButton({ children, callBack }) {
   );
 }
 
-function HeaderButton({ children, callBack }) {
-  const style = `flex flex-row
-                 min-h-full
-                 bg-blue-100 hover:bg-blue-700
-                 text-base text-blue-800 font-semibold hover:text-white
-                 py-2 px-4
-                 border-r-2 border-l-2 hover:border-blue-700
-                 cursor-pointer`;
-
-  return (
-    <Button callBack={callBack} css={style}>
-      {children}
-    </Button>
-  );
-}
-
 function BlueButton({ children, callBack }) {
   const blueStyle = `
                  bg-blue-500 hover:bg-blue-700
@@ -98,5 +82,4 @@ export {
   OutlineSubmitButton,
   BlueSubmitButton,
   BlueButton,
-  HeaderButton,
 };

--- a/src/CalendarYearTable.js
+++ b/src/CalendarYearTable.js
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import Modal from "./Modal";
 import { range, createCells } from "./utils";
-import EventList from "./EventList";
+import DayModal from "./DayModal";
 dayjs.extend(LocalizedFormat);
 
 function CalendarYearTable({ year }) {
@@ -13,11 +13,17 @@ function CalendarYearTable({ year }) {
   const css = { cellBorders: "border border-gray-500" };
   const dummyEvents = {
     "2020-04-13": [
-      { date: "2020-04-13", time: "15:00", title: "go to the beach" },
+      { date: "2020-04-13", time: "11:00", title: "go to the beach" },
       {
         date: "2020-04-13",
         time: "17:00",
         title: "play FF7 with Ryan and Simon",
+      },
+      {
+        date: "2020-04-13",
+        time: "21:00",
+        title:
+          "Drinks with Natasha and Pepito at the hacienda near the cemetery.",
       },
     ],
     "2020-04-19": [{ date: "2020-04-19", time: "15:00", title: "confinement" }],
@@ -166,7 +172,7 @@ function DayCell({ date, events, css, onAddEvent }) {
         {weekday[0]}
       </td>
       <Modal showModal={showModal} onCloseModal={closeModal}>
-        <EventList date={date} events={events} onAddEvent={onAddEvent} />
+        <DayModal date={date} events={events} onAddEvent={onAddEvent} />
       </Modal>
     </>
   );

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -26,7 +26,7 @@ function DayModal({ date, events, onAddEvent }) {
         />
       </div>
       <div className="grid grid-cols-3 gap-8 w-full mt-6">
-        <EventList events={events} />
+        {events && <EventList events={events} />}
       </div>
     </div>
   );

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -91,7 +91,6 @@ function EventCol({ events, title }) {
   const titleTextColor =
     events && events.length > 0 ? "text-gray-800" : "text-gray-400";
 
-  useEffect(() => console.log(events));
   return (
     <div className="">
       <div className="py-2">

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -1,9 +1,9 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import isBetween from "dayjs/plugin/isBetween";
-import { BlueButton } from "./Button";
+import { HeaderButton } from "./Button";
 import EventForm from "./EventForm";
 dayjs.extend(customParseFormat);
 dayjs.extend(isBetween);
@@ -12,19 +12,24 @@ function DayModal({ date, events, onAddEvent }) {
   const [displayForm, setDisplayForm] = useState(false);
 
   return (
-    <div className="h-full flex flex-col mx-2">
-      <h2 className="block text-3xl font-medium text-gray-800 leading-loose border-b-2 border-gray-300">
-        {dayjs(date).format("dddd")} {dayjs(date).format("LL")}
-      </h2>
-      <div className="mt-4 pb-4">
-        <BlueButton callBack={() => setDisplayForm(true)}>Add Event</BlueButton>
-        <EventForm
-          date={date}
-          display={displayForm}
-          onAddEvent={onAddEvent}
-          onClose={() => setDisplayForm(false)}
-        />
-      </div>
+    <div className="h-full flex flex-col mx-8">
+      <header className="border-b-2 border-t-2 border-gray-300 flex flex-row">
+        <h2 className="inline-block text-3xl font-medium text-gray-800 leading-loose mr-4">
+          {dayjs(date).format("dddd")} {dayjs(date).format("LL")}
+        </h2>
+        <div className="relative h-full flex-grow">
+          <HeaderButton callBack={() => setDisplayForm(true)}>
+            <i className="gg-add-r h-full mr-2"></i>Add Event
+          </HeaderButton>
+          <EventForm
+            date={date}
+            display={displayForm}
+            onAddEvent={onAddEvent}
+            onClose={() => setDisplayForm(false)}
+          />
+        </div>
+      </header>
+
       <div className="grid grid-cols-3 gap-8 w-full mt-6">
         {events && <EventList events={events} />}
       </div>
@@ -78,15 +83,19 @@ function EventList({ events }) {
   );
 }
 
-DayModal.propTypes = {
+EventList.propTypes = {
   events: PropTypes.array,
 };
 
 function EventCol({ events, title }) {
+  const titleTextColor =
+    events && events.length > 0 ? "text-gray-800" : "text-gray-400";
+
+  useEffect(() => console.log(events));
   return (
     <div className="">
       <div className="py-2">
-        <h2 className="text-xl font-medium text-gray-800">{title}</h2>
+        <h2 className={`text-xl font-medium ${titleTextColor}`}>{title}</h2>
       </div>
       <div className="h-auto flex self-stretch mt-4 mb-6 pb-6">
         <ul className="block w-full list-inside list-disc text-gray-800">

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import isBetween from "dayjs/plugin/isBetween";
-import { HeaderButton } from "./Button";
+import { Button } from "./Button";
 import EventForm from "./EventForm";
 dayjs.extend(customParseFormat);
 dayjs.extend(isBetween);
@@ -72,13 +72,9 @@ function EventList({ events }) {
 
   return (
     <>
-      <EventCol events={morningEvents} title="Morning"></EventCol>
-      <EventCol events={afternoonEvents} title="Afternoon">
-        <h2>Afternoon</h2>
-      </EventCol>
-      <EventCol events={eveningEvents} title="Evening">
-        <h2>Evening</h2>
-      </EventCol>
+      <EventCol events={morningEvents} title="Morning" />
+      <EventCol events={afternoonEvents} title="Afternoon" />
+      <EventCol events={eveningEvents} title="Evening" />
     </>
   );
 }
@@ -114,6 +110,22 @@ function Event({ event }) {
       </div>
       <div className="mt-2">{event.title}</div>
     </li>
+  );
+}
+
+function HeaderButton({ children, callBack }) {
+  const style = `flex flex-row
+                 min-h-full
+                 bg-blue-100 hover:bg-blue-700
+                 text-base text-blue-800 font-semibold hover:text-white
+                 py-2 px-4
+                 border-r-2 border-l-2 hover:border-blue-700
+                 cursor-pointer`;
+
+  return (
+    <Button callBack={callBack} css={style}>
+      {children}
+    </Button>
   );
 }
 

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -1,0 +1,112 @@
+import React, { useEffect, useState, useRef } from "react";
+import PropTypes from "prop-types";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import isBetween from "dayjs/plugin/isBetween";
+import { BlueButton } from "./Button";
+import EventForm from "./EventForm";
+dayjs.extend(customParseFormat);
+dayjs.extend(isBetween);
+
+function DayModal({ date, events, onAddEvent }) {
+  const [displayForm, setDisplayForm] = useState(false);
+
+  return (
+    <div className="h-full flex flex-col mx-2">
+      <h2 className="block text-3xl font-medium text-gray-800 leading-loose border-b-2 border-gray-300">
+        {dayjs(date).format("dddd")} {dayjs(date).format("LL")}
+      </h2>
+      <div className="mt-4 pb-4">
+        <BlueButton callBack={() => setDisplayForm(true)}>Add Event</BlueButton>
+        <EventForm
+          date={date}
+          display={displayForm}
+          onAddEvent={onAddEvent}
+          onClose={() => setDisplayForm(false)}
+        />
+      </div>
+      <div className="grid grid-cols-3 gap-8 w-full mt-6">
+        <EventList events={events} />
+      </div>
+    </div>
+  );
+}
+
+DayModal.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  events: PropTypes.array,
+  onAddEvent: PropTypes.func.isRequired,
+};
+
+function EventList({ events }) {
+  const sortedEvents =
+    events &&
+    events.sort((a, b) => {
+      const aTime = dayjs(a.time, "HH:mm");
+      const bTime = dayjs(b.time, "HH:mm");
+
+      return aTime - bTime;
+    });
+
+  const filterEventsBetween = (eventList, lowerLimit, upperLimit) => {
+    if (!eventList) return false;
+    return eventList.filter((event) => {
+      const eventTime = dayjs(event.time, "HH:mm");
+      return eventTime.isBetween(
+        dayjs(lowerLimit, "HH:mm"),
+        dayjs(upperLimit, "HH:mm"),
+        null,
+        "[)"
+      );
+    });
+  };
+
+  const morningEvents = filterEventsBetween(sortedEvents, "00:00", "11:59");
+  const afternoonEvents = filterEventsBetween(sortedEvents, "12:00", "18:59");
+  const eveningEvents = filterEventsBetween(sortedEvents, "19:00", "23:59");
+
+  return (
+    <>
+      <EventCol events={morningEvents} title="Morning"></EventCol>
+      <EventCol events={afternoonEvents} title="Afternoon">
+        <h2>Afternoon</h2>
+      </EventCol>
+      <EventCol events={eveningEvents} title="Evening">
+        <h2>Evening</h2>
+      </EventCol>
+    </>
+  );
+}
+
+DayModal.propTypes = {
+  events: PropTypes.array,
+};
+
+function EventCol({ events, title }) {
+  return (
+    <div className="">
+      <div className="py-2">
+        <h2 className="text-xl font-medium text-gray-800">{title}</h2>
+      </div>
+      <div className="h-auto flex self-stretch mt-4 mb-6 pb-6">
+        <ul className="block w-full list-inside list-disc text-gray-800">
+          {events &&
+            events.map((event, idx) => <Event key={idx} event={event} />)}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function Event({ event }) {
+  return (
+    <li className="block w-full h-auto mb-4 p-4 border-2 text-lg text-gray-800 border-gray-300 hover:border-blue-600">
+      <div className="h-auto py-1 font-bold tracking-wider border-b-2 border-gray-300">
+        {event.time}
+      </div>
+      <div className="mt-2">{event.title}</div>
+    </li>
+  );
+}
+
+export default DayModal;

--- a/src/EventForm.js
+++ b/src/EventForm.js
@@ -56,7 +56,7 @@ function EventForm({ date, display, onAddEvent, onClose }) {
       {display && (
         <form
           action=""
-          className="mt-1 p-4 bg-gray-100 border border-blue-800 w-1/3"
+          className="block absolute left-0 my-2 p-4 bg-gray-100 border border-blue-800 w-full min-w-full shadow-lg"
           onSubmit={handleSubmit}
         >
           <div
@@ -97,7 +97,7 @@ function EventForm({ date, display, onAddEvent, onClose }) {
               display={minutesPickerShown}
             />
           </div>
-          <div className="mt-2">
+          <div className="mt-4">
             <BlueSubmitButton />
           </div>
         </form>

--- a/src/EventForm.js
+++ b/src/EventForm.js
@@ -1,53 +1,8 @@
-import React from "react";
-import { useEffect, useState, useRef } from "react";
+import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
-import { Button, OutlineButton, BlueSubmitButton, BlueButton } from "./Button";
+import { Button, OutlineButton, BlueSubmitButton } from "./Button";
 import { range } from "./utils";
-
-function EventList({ date, events, onAddEvent }) {
-  const [displayForm, setDisplayForm] = useState(false);
-
-  return (
-    <div className="h-full flex flex-col mx-2">
-      <h2 className="block text-xl font-medium text-gray-800 leading-loose border-b-2 border-gray-300">
-        {dayjs(date).format("LL")}{" "}
-      </h2>
-      <div className="mt-6">
-        <BlueButton callBack={() => setDisplayForm(true)}>Add Event</BlueButton>
-        <EventForm
-          date={date}
-          display={displayForm}
-          onAddEvent={onAddEvent}
-          onClose={() => setDisplayForm(false)}
-        />
-      </div>
-      <div className="h-auto flex self-stretch mt-6 mb-6 pb-6">
-        <ul className="block w-full list-inside list-disc text-gray-800">
-          {events &&
-            events.map((event, idx) => <Event key={idx} event={event} />)}
-        </ul>
-      </div>
-    </div>
-  );
-}
-
-EventList.propTypes = {
-  date: PropTypes.instanceOf(Date).isRequired,
-  events: PropTypes.array,
-  onAddEvent: PropTypes.func.isRequired,
-};
-
-function Event({ event }) {
-  return (
-    <li className="block w-full flex flex-row h-auto p-2 mb-2 hover:bg-gray-100 border border-transparent hover:border-gray-300">
-      <div className="border-r-2 border-red-600 h-auto font-bold pr-4 mr-4">
-        {event.time}
-      </div>
-      <div className="">{event.title}</div>
-    </li>
-  );
-}
 
 function EventForm({ date, display, onAddEvent, onClose }) {
   const titleInput = useRef();
@@ -101,7 +56,7 @@ function EventForm({ date, display, onAddEvent, onClose }) {
       {display && (
         <form
           action=""
-          className="mt-1 p-4 bg-gray-100 border border-blue-800"
+          className="mt-1 p-4 bg-gray-100 border border-blue-800 w-1/3"
           onSubmit={handleSubmit}
         >
           <div
@@ -226,4 +181,4 @@ function EventLabel({ children }) {
   );
 }
 
-export default EventList;
+export default EventForm;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -20,7 +20,7 @@ function ModalContent({ children, onCloseModal }) {
       className="fixed top-0 left-0 w-screen h-screen flex items-center"
       style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
     >
-      <div className="static box-border top-0 right-0 h-screen w-1/2 max-w-xl p-2 bg-white border shadow-md">
+      <div className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md">
         <div className="w-full flex items-center justify-end flex-wrap p-1">
           <OutlineButton callBack={() => onCloseModal()}>✕</OutlineButton>
         </div>


### PR DESCRIPTION
Improved the day modal page: 
- created a proper header to make sure the *add event* button does not float.
- splitted the day into 3 time periods : morning, afternoon and evening. 

People think about events and meetings as done during morning, afternoon, evening, night. Everyone split time into chunks, yet for some reason no calendar seems to take care to reproduce this behavior. I think that it allows to scan daily content faster and allows for a better use of screen space, as events are displayed in columns.

The main challenge I met here was allowing the event form to appear above the content. I had to get inspiration from dropdown menus as it is, in essence, the same behavior. 
One other challenge was understanding how to do this with tailwind and flex utilities. It works well now, but I struggled until I discovered a video from the very team of tailwind.

It works well !

As usual, buttons are becoming a real mess. While making the header I had to change a lot of stuff to make the button I wanted. I'm procrastinating about this but I should really get it done.