### PR TITLE
Add events details page

### DIFF
--- a/src/CalendarYearTable.js
+++ b/src/CalendarYearTable.js
@@ -17,17 +17,8 @@ function CalendarYearTable({ year }) {
   const cells = createYearCalendarCells(year, events);
 
   function addEvent(event) {
-    let newEvents;
-    if (events[event.date]) {
-      newEvents = [...events[event.date], event];
-    } else {
-      newEvents = [event];
-    }
-
-    setEvents({
-      ...events,
-      [event.date]: newEvents,
-    });
+    const newEvent = { ...event, id: events.length + 1 };
+    setEvents([...events, newEvent]);
   }
 
   return (
@@ -130,7 +121,7 @@ function DayCell({ date, events, css, onAddEvent }) {
     const isPast = currentDate.isBefore(today);
     const isToday = currentDate.isSame(today);
 
-    if (events)
+    if (events.length > 0)
       return `bg-orange-300 text-orange-800 hover:bg-orange-400 hover:text-white`;
     if (isCurrentYear && isPast && weekday === "Sunday")
       return `hover:bg-gray-200 text-red-300`;

--- a/src/CalendarYearTable.js
+++ b/src/CalendarYearTable.js
@@ -21,6 +21,10 @@ function CalendarYearTable({ year }) {
     setEvents([...events, newEvent]);
   }
 
+  function deleteEvent(event) {
+    setEvents(events.filter((e) => e.id !== event.id));
+  }
+
   return (
     <table className="table-fixed w-full border text-xs bg-white">
       <thead className={`${css.cellBorders}`}>
@@ -41,6 +45,7 @@ function CalendarYearTable({ year }) {
               key={monthDay}
               css={css}
               onAddEvent={addEvent}
+              onDeleteEvent={deleteEvent}
             />
           );
         })}
@@ -79,7 +84,7 @@ function MonthsRow({ css }) {
   );
 }
 
-function DaysRow({ days, css, onAddEvent }) {
+function DaysRow({ days, css, onAddEvent, onDeleteEvent }) {
   const tdClass = `${css.cellBorders} font-semibold text-center text-gray-700`;
   const monthDay = dayjs(days[0].date).format("D");
 
@@ -94,6 +99,7 @@ function DaysRow({ days, css, onAddEvent }) {
             css={css}
             key={id}
             onAddEvent={onAddEvent}
+            onDeleteEvent={onDeleteEvent}
           />
         ) : (
           <EmptyCell css={css} key={id} />
@@ -108,7 +114,7 @@ function EmptyCell({ css }) {
   return <td className={`${css.cellBorders}`}></td>;
 }
 
-function DayCell({ date, events, css, onAddEvent }) {
+function DayCell({ date, events, css, onAddEvent, onDeleteEvent }) {
   const [showModal, setShowModal] = useState(false);
   const closeModal = () => setShowModal(false);
 
@@ -144,7 +150,12 @@ function DayCell({ date, events, css, onAddEvent }) {
         {weekday[0]}
       </td>
       <Modal showModal={showModal} onCloseModal={closeModal}>
-        <DayModal date={date} events={events} onAddEvent={onAddEvent} />
+        <DayModal
+          date={date}
+          events={events}
+          onAddEvent={onAddEvent}
+          onDeleteEvent={onDeleteEvent}
+        />
       </Modal>
     </>
   );

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import isBetween from "dayjs/plugin/isBetween";
-import { Button } from "./Button";
+import { Button, OutlineButton } from "./Button";
 import EventForm from "./EventForm";
 dayjs.extend(customParseFormat);
 dayjs.extend(isBetween);
@@ -16,6 +16,15 @@ function DayModal({ date, events, onAddEvent }) {
     setChosenEvent(calEvent);
   }
 
+  const resetChosenEvent = () => setChosenEvent(undefined);
+
+  function setCurrentPage() {
+    if (chosenEvent) return "event";
+    if (!chosenEvent && events) return "eventList";
+    return "none";
+  }
+
+  const currentPage = setCurrentPage();
   return (
     <div className="h-full flex flex-col mx-8">
       <header className="border-b-2 border-gray-300 flex flex-row items-center">
@@ -36,8 +45,19 @@ function DayModal({ date, events, onAddEvent }) {
         </div>
       </header>
       <HoursList events={events} />
-
-      {events && <EventList events={events} onChooseEvent={chooseCalEvent} />}
+      <>
+        {currentPage === "event" && (
+          <EventDetails
+            event={chosenEvent}
+            onCloseEventDetails={resetChosenEvent}
+          />
+        )}
+      </>
+      <>
+        {currentPage === "eventList" && (
+          <EventList events={events} onChooseEvent={chooseCalEvent} />
+        )}
+      </>
     </div>
   );
 }
@@ -47,6 +67,24 @@ DayModal.propTypes = {
   events: PropTypes.array,
   onAddEvent: PropTypes.func.isRequired,
 };
+
+function EventDetails({ event, onCloseEventDetails }) {
+  return (
+    <div className="h-full flex flex-row justify between w-full my-10 text-gray-800">
+      <div className="font-bold text-3xl tracking-wider pr-4 border-r-2 border-gray-300">
+        {event.time}
+      </div>
+      <div className="ml-5 flex flex-grow">
+        <div className="flex-grow text-2xl">{event.title}</div>
+        <div className="flex flex-none items-start justify-end">
+          <OutlineButton callBack={() => onCloseEventDetails()}>
+            ✕
+          </OutlineButton>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function HoursList({ events }) {
   const sortedEvents =
@@ -102,7 +140,7 @@ function EventList({ events, onChooseEvent }) {
   const eveningEvents = filterEventsBetween(sortedEvents, "19:00", "23:59");
 
   return (
-    <div className="grid grid-cols-3 gap-8 w-full mt-6">
+    <div className="grid grid-cols-3 gap-8 w-full mt-10">
       <EventCol
         events={morningEvents}
         onChooseEvent={onChooseEvent}

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -7,7 +7,7 @@ import EventForm from "./EventForm";
 import EventContainer from "./EventContainer";
 dayjs.extend(customParseFormat);
 
-function DayModal({ date, events, onAddEvent }) {
+function DayModal({ date, events, onAddEvent, onDeleteEvent }) {
   const [displayForm, setDisplayForm] = useState(false);
 
   return (
@@ -29,7 +29,7 @@ function DayModal({ date, events, onAddEvent }) {
           />
         </div>
       </header>
-      <EventContainer events={events} />
+      <EventContainer events={events} onDeleteEvent={onDeleteEvent} />
     </div>
   );
 }

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -2,38 +2,23 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import isBetween from "dayjs/plugin/isBetween";
-import { Button, OutlineButton } from "./Button";
+import { Button } from "./Button";
 import EventForm from "./EventForm";
+import EventContainer from "./EventContainer";
 dayjs.extend(customParseFormat);
-dayjs.extend(isBetween);
 
 function DayModal({ date, events, onAddEvent }) {
   const [displayForm, setDisplayForm] = useState(false);
-  const [chosenEvent, setChosenEvent] = useState(undefined);
 
-  function chooseCalEvent(calEvent) {
-    setChosenEvent(calEvent);
-  }
-
-  const resetChosenEvent = () => setChosenEvent(undefined);
-
-  function setCurrentPage() {
-    if (chosenEvent) return "event";
-    if (!chosenEvent && events) return "eventList";
-    return "none";
-  }
-
-  const currentPage = setCurrentPage();
   return (
     <div className="h-full flex flex-col mx-8">
-      <header className="border-b-2 border-gray-300 flex flex-row items-center">
+      <header className="flex flex-row items-center">
         <h2 className="inline-block text-3xl font-medium text-gray-800 leading-loose mr-4">
           {dayjs(date).format("dddd")} {dayjs(date).format("LL")}
         </h2>
         <div className="relative flex-grow">
           <HeaderButton callBack={() => setDisplayForm(true)}>
-            <i className="gg-add-r h-full mr-2"></i>Add Event
+            <i className="gg-add-r h-full mr-3"></i>Add Event
           </HeaderButton>
           <EventForm
             events={events}
@@ -44,20 +29,7 @@ function DayModal({ date, events, onAddEvent }) {
           />
         </div>
       </header>
-      <HoursList events={events} />
-      <>
-        {currentPage === "event" && (
-          <EventDetails
-            event={chosenEvent}
-            onCloseEventDetails={resetChosenEvent}
-          />
-        )}
-      </>
-      <>
-        {currentPage === "eventList" && (
-          <EventList events={events} onChooseEvent={chooseCalEvent} />
-        )}
-      </>
+      <EventContainer events={events} />
     </div>
   );
 }
@@ -66,156 +38,6 @@ DayModal.propTypes = {
   date: PropTypes.instanceOf(Date).isRequired,
   events: PropTypes.array,
   onAddEvent: PropTypes.func.isRequired,
-};
-
-function EventDetails({ event, onCloseEventDetails }) {
-  return (
-    <div className="h-full flex flex-row justify between w-full my-10 text-gray-800">
-      <div className="font-bold text-3xl tracking-wider pr-4 border-r-2 border-gray-300">
-        {event.time}
-      </div>
-      <div className="ml-5 flex flex-grow">
-        <div className="flex-grow text-2xl">{event.title}</div>
-        <div className="flex flex-none items-start justify-end">
-          <OutlineButton callBack={() => onCloseEventDetails()}>
-            ✕
-          </OutlineButton>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function HoursList({ events }) {
-  const sortedEvents =
-    events &&
-    events.sort((a, b) => {
-      const aTime = dayjs(a.time, "HH:mm");
-      const bTime = dayjs(b.time, "HH:mm");
-
-      return aTime - bTime;
-    });
-  return (
-    <>
-      {events && (
-        <div className="border-b-2 border-gray-300 flex flex-row">
-          <ul className="flex flex-row divide-x-2 divide-gray-300 text-gray-800">
-            {sortedEvents.map((event) => (
-              <li className="p-2" key={event.id}>
-                {event.time}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </>
-  );
-}
-
-function EventList({ events, onChooseEvent }) {
-  const sortedEvents =
-    events &&
-    events.sort((a, b) => {
-      const aTime = dayjs(a.time, "HH:mm");
-      const bTime = dayjs(b.time, "HH:mm");
-
-      return aTime - bTime;
-    });
-
-  const filterEventsBetween = (eventList, lowerLimit, upperLimit) => {
-    if (!eventList) return false;
-    return eventList.filter((event) => {
-      const eventTime = dayjs(event.time, "HH:mm");
-      return eventTime.isBetween(
-        dayjs(lowerLimit, "HH:mm"),
-        dayjs(upperLimit, "HH:mm"),
-        null,
-        "[)"
-      );
-    });
-  };
-
-  const morningEvents = filterEventsBetween(sortedEvents, "00:00", "11:59");
-  const afternoonEvents = filterEventsBetween(sortedEvents, "12:00", "18:59");
-  const eveningEvents = filterEventsBetween(sortedEvents, "19:00", "23:59");
-
-  return (
-    <div className="grid grid-cols-3 gap-8 w-full mt-10">
-      <EventCol
-        events={morningEvents}
-        onChooseEvent={onChooseEvent}
-        title="Morning"
-      />
-      <EventCol
-        events={afternoonEvents}
-        onChooseEvent={onChooseEvent}
-        title="Afternoon"
-      />
-      <EventCol
-        events={eveningEvents}
-        onChooseEvent={onChooseEvent}
-        title="Evening"
-      />
-    </div>
-  );
-}
-
-EventList.propTypes = {
-  events: PropTypes.array,
-  onChooseEvent: PropTypes.func.isRequired,
-};
-
-function EventCol({ events, title, onChooseEvent }) {
-  const titleTextColor =
-    events && events.length > 0 ? "text-gray-800" : "text-gray-400";
-
-  return (
-    <div className="">
-      <div className="py-2">
-        <h2 className={`text-xl font-medium ${titleTextColor}`}>{title}</h2>
-      </div>
-      <div className="h-auto flex self-stretch mt-4 mb-6 pb-6">
-        <ul className="block w-full list-inside list-disc text-gray-800">
-          {events &&
-            events.map((event, idx) => (
-              <Event key={idx} event={event} onChooseEvent={onChooseEvent} />
-            ))}
-        </ul>
-      </div>
-    </div>
-  );
-}
-
-EventCol.propTypes = {
-  events: PropTypes.array.isRequired,
-  title: PropTypes.string.isRequired,
-  onChooseEvent: PropTypes.func.isRequired,
-};
-
-function Event({ event, onChooseEvent }) {
-  const style = `block w-full h-auto 
-    mb-4 p-4 
-    border-2  border-gray-300 hover:border-blue-600
-    text-lg text-gray-800
-    cursor-pointer`;
-
-  const chooseEvent = (event) => {
-    onChooseEvent(event);
-  };
-
-  return (
-    <li className={style} onClick={() => chooseEvent(event)}>
-      <div className="h-auto py-1 font-bold tracking-wider border-b-2 border-gray-300">
-        {event.time}
-      </div>
-      <div className="mt-2">{event.title}</div>
-    </li>
-  );
-}
-
-Event.propTypes = {
-  event: PropTypes.object.isRequired,
-  onChooseEvent: PropTypes.func.isRequired,
 };
 
 function HeaderButton({ children, callBack }) {

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -13,11 +13,11 @@ function DayModal({ date, events, onAddEvent }) {
 
   return (
     <div className="h-full flex flex-col mx-8">
-      <header className="border-b-2 border-t-2 border-gray-300 flex flex-row">
+      <header className="border-b-2 border-gray-300 flex flex-row items-center">
         <h2 className="inline-block text-3xl font-medium text-gray-800 leading-loose mr-4">
           {dayjs(date).format("dddd")} {dayjs(date).format("LL")}
         </h2>
-        <div className="relative h-full flex-grow">
+        <div className="relative flex-grow">
           <HeaderButton callBack={() => setDisplayForm(true)}>
             <i className="gg-add-r h-full mr-2"></i>Add Event
           </HeaderButton>
@@ -29,7 +29,7 @@ function DayModal({ date, events, onAddEvent }) {
           />
         </div>
       </header>
-
+      <HoursList events={events} />
       <div className="grid grid-cols-3 gap-8 w-full mt-6">
         {events && <EventList events={events} />}
       </div>
@@ -42,6 +42,30 @@ DayModal.propTypes = {
   events: PropTypes.array,
   onAddEvent: PropTypes.func.isRequired,
 };
+
+function HoursList({ events }) {
+  const sortedEvents =
+    events &&
+    events.sort((a, b) => {
+      const aTime = dayjs(a.time, "HH:mm");
+      const bTime = dayjs(b.time, "HH:mm");
+
+      return aTime - bTime;
+    });
+  return (
+    <>
+      {events && (
+        <div className="border-b-2 border-gray-300 flex flex-row">
+          <ul className="flex flex-row divide-x-2 divide-gray-300 text-gray-800">
+            {sortedEvents.map((event) => (
+              <li className="p-2">{event.time}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}
 
 function EventList({ events }) {
   const sortedEvents =
@@ -114,12 +138,11 @@ function Event({ event }) {
 }
 
 function HeaderButton({ children, callBack }) {
-  const style = `flex flex-row
-                 min-h-full
-                 bg-blue-100 hover:bg-blue-700
-                 text-base text-blue-800 font-semibold hover:text-white
+  const style = `flex flex-row items-center
+                 bg-blue-700 hover:bg-blue-500
+                 text-xs text-white font-semibold align-middle hover:text-white
                  py-2 px-4
-                 border-r-2 border-l-2 hover:border-blue-700
+                 rounded
                  cursor-pointer`;
 
   return (

--- a/src/DayModal.js
+++ b/src/DayModal.js
@@ -10,6 +10,11 @@ dayjs.extend(isBetween);
 
 function DayModal({ date, events, onAddEvent }) {
   const [displayForm, setDisplayForm] = useState(false);
+  const [chosenEvent, setChosenEvent] = useState(undefined);
+
+  function chooseCalEvent(calEvent) {
+    setChosenEvent(calEvent);
+  }
 
   return (
     <div className="h-full flex flex-col mx-8">
@@ -22,6 +27,7 @@ function DayModal({ date, events, onAddEvent }) {
             <i className="gg-add-r h-full mr-2"></i>Add Event
           </HeaderButton>
           <EventForm
+            events={events}
             date={date}
             display={displayForm}
             onAddEvent={onAddEvent}
@@ -30,9 +36,8 @@ function DayModal({ date, events, onAddEvent }) {
         </div>
       </header>
       <HoursList events={events} />
-      <div className="grid grid-cols-3 gap-8 w-full mt-6">
-        {events && <EventList events={events} />}
-      </div>
+
+      {events && <EventList events={events} onChooseEvent={chooseCalEvent} />}
     </div>
   );
 }
@@ -58,7 +63,9 @@ function HoursList({ events }) {
         <div className="border-b-2 border-gray-300 flex flex-row">
           <ul className="flex flex-row divide-x-2 divide-gray-300 text-gray-800">
             {sortedEvents.map((event) => (
-              <li className="p-2">{event.time}</li>
+              <li className="p-2" key={event.id}>
+                {event.time}
+              </li>
             ))}
           </ul>
         </div>
@@ -67,7 +74,7 @@ function HoursList({ events }) {
   );
 }
 
-function EventList({ events }) {
+function EventList({ events, onChooseEvent }) {
   const sortedEvents =
     events &&
     events.sort((a, b) => {
@@ -95,19 +102,32 @@ function EventList({ events }) {
   const eveningEvents = filterEventsBetween(sortedEvents, "19:00", "23:59");
 
   return (
-    <>
-      <EventCol events={morningEvents} title="Morning" />
-      <EventCol events={afternoonEvents} title="Afternoon" />
-      <EventCol events={eveningEvents} title="Evening" />
-    </>
+    <div className="grid grid-cols-3 gap-8 w-full mt-6">
+      <EventCol
+        events={morningEvents}
+        onChooseEvent={onChooseEvent}
+        title="Morning"
+      />
+      <EventCol
+        events={afternoonEvents}
+        onChooseEvent={onChooseEvent}
+        title="Afternoon"
+      />
+      <EventCol
+        events={eveningEvents}
+        onChooseEvent={onChooseEvent}
+        title="Evening"
+      />
+    </div>
   );
 }
 
 EventList.propTypes = {
   events: PropTypes.array,
+  onChooseEvent: PropTypes.func.isRequired,
 };
 
-function EventCol({ events, title }) {
+function EventCol({ events, title, onChooseEvent }) {
   const titleTextColor =
     events && events.length > 0 ? "text-gray-800" : "text-gray-400";
 
@@ -119,16 +139,34 @@ function EventCol({ events, title }) {
       <div className="h-auto flex self-stretch mt-4 mb-6 pb-6">
         <ul className="block w-full list-inside list-disc text-gray-800">
           {events &&
-            events.map((event, idx) => <Event key={idx} event={event} />)}
+            events.map((event, idx) => (
+              <Event key={idx} event={event} onChooseEvent={onChooseEvent} />
+            ))}
         </ul>
       </div>
     </div>
   );
 }
 
-function Event({ event }) {
+EventCol.propTypes = {
+  events: PropTypes.array.isRequired,
+  title: PropTypes.string.isRequired,
+  onChooseEvent: PropTypes.func.isRequired,
+};
+
+function Event({ event, onChooseEvent }) {
+  const style = `block w-full h-auto 
+    mb-4 p-4 
+    border-2  border-gray-300 hover:border-blue-600
+    text-lg text-gray-800
+    cursor-pointer`;
+
+  const chooseEvent = (event) => {
+    onChooseEvent(event);
+  };
+
   return (
-    <li className="block w-full h-auto mb-4 p-4 border-2 text-lg text-gray-800 border-gray-300 hover:border-blue-600">
+    <li className={style} onClick={() => chooseEvent(event)}>
       <div className="h-auto py-1 font-bold tracking-wider border-b-2 border-gray-300">
         {event.time}
       </div>
@@ -136,6 +174,11 @@ function Event({ event }) {
     </li>
   );
 }
+
+Event.propTypes = {
+  event: PropTypes.object.isRequired,
+  onChooseEvent: PropTypes.func.isRequired,
+};
 
 function HeaderButton({ children, callBack }) {
   const style = `flex flex-row items-center

--- a/src/EventContainer.js
+++ b/src/EventContainer.js
@@ -36,6 +36,7 @@ function EventContainer({ events, onDeleteEvent }) {
       <EventsMenu
         events={sortedEvents}
         isDisplayed={currentPage !== "none"}
+        chosenEvent={chosenEvent}
         onChoosePage={choosePage}
       />
       {currentPage === "event" && (
@@ -50,13 +51,13 @@ function EventContainer({ events, onDeleteEvent }) {
   );
 }
 
-function EventsMenu({ events, isDisplayed, onChoosePage }) {
+function EventsMenu({ events, isDisplayed, onChoosePage, chosenEvent }) {
   return (
     <>
       {isDisplayed && (
         <div className="flex mb-10 space-x-2">
           <HorizontalMenu>
-            <MenuItem callBack={() => onChoosePage()}>
+            <MenuItem callBack={() => onChoosePage()} isSelected={!chosenEvent}>
               <i className="gg-list transform scale-90 mr-3"></i> Planning
             </MenuItem>
           </HorizontalMenu>
@@ -64,7 +65,11 @@ function EventsMenu({ events, isDisplayed, onChoosePage }) {
             {events.length > 0 && (
               <HorizontalMenu>
                 {events.map((event) => (
-                  <MenuItem key={event.id} callBack={() => onChoosePage(event)}>
+                  <MenuItem
+                    key={event.id}
+                    callBack={() => onChoosePage(event)}
+                    isSelected={event === chosenEvent}
+                  >
                     {event.time}
                   </MenuItem>
                 ))}
@@ -85,10 +90,12 @@ function HorizontalMenu({ children }) {
   );
 }
 
-function MenuItem({ children, callBack }) {
+function MenuItem({ children, isSelected, callBack }) {
   return (
     <li
-      className="flex px-4 pb-2 border-b-4 border-white hover:border-blue-600"
+      className={`flex px-4 pb-2 border-b-4 border-white ${
+        isSelected ? "border-blue-600" : ""
+      } hover:border-blue-600`}
       onClick={callBack}
     >
       {children}

--- a/src/EventContainer.js
+++ b/src/EventContainer.js
@@ -5,7 +5,7 @@ import isBetween from "dayjs/plugin/isBetween";
 import { Button } from "./Button";
 dayjs.extend(isBetween);
 
-function EventContainer({ events }) {
+function EventContainer({ events, onDeleteEvent }) {
   const [chosenEvent, setChosenEvent] = useState(undefined);
 
   const choosePage = (calEvent) => {
@@ -15,6 +15,11 @@ function EventContainer({ events }) {
     if (chosenEvent) return "event";
     if (!chosenEvent && events.length > 0) return "eventList";
     return "none";
+  }
+
+  function handleDeleteEvent(event) {
+    setChosenEvent(undefined);
+    onDeleteEvent(event);
   }
 
   const currentPage = setCurrentPage();
@@ -33,7 +38,9 @@ function EventContainer({ events }) {
         isDisplayed={currentPage !== "none"}
         onChoosePage={choosePage}
       />
-      {currentPage === "event" && <EventDetails event={chosenEvent} />}
+      {currentPage === "event" && (
+        <EventDetails event={chosenEvent} onDeleteEvent={handleDeleteEvent} />
+      )}
       <>
         {currentPage === "eventList" && (
           <EventList events={sortedEvents} onChooseEvent={choosePage} />
@@ -70,7 +77,7 @@ function EventsMenu({ events, isDisplayed, onChoosePage }) {
   );
 }
 
-function HorizontalMenu({ children, callBack }) {
+function HorizontalMenu({ children }) {
   return (
     <ul className="bg-white flex flex-row text-sm rounded px-3 pt-3 items-center">
       {children}
@@ -91,16 +98,16 @@ function MenuItem({ children, callBack }) {
 
 function EventDetails({ event, onDeleteEvent }) {
   return (
-    <div className="flex flex-row justify between w-full p-10 bg-white text-gray-800 rounded-lg">
+    <div className="flex flex-row justify between w-full space-x-5 p-10 bg-white text-gray-800 rounded-lg">
       <div className="font-bold text-2xl text-blue-700 tracking-wider pr-4 border-r-2 border-gray-300">
         {event.time}
       </div>
-      <div className="ml-5 flex flex-grow">
+      <div className="flex flex-grow">
         <div className="flex-grow text-2xl">{event.title}</div>
       </div>
-      <div className="ml-5 justify-end">
-        <DeleteButton callBack={onDeleteEvent}>
-          <i class="gg-trash mr-3"></i> Delete
+      <div className="justify-end">
+        <DeleteButton callBack={() => onDeleteEvent(event)}>
+          <i className="gg-trash mr-3"></i> Delete
         </DeleteButton>
       </div>
     </div>
@@ -206,11 +213,11 @@ Event.propTypes = {
 };
 
 function DeleteButton({ children, callBack }) {
-  const outlineStyle = `bg-transparent hover:bg-red-800
-                 text-sm text-red-700 font-semibold hover:text-white
-                 py-3 px-4
+  const outlineStyle = `flex flex-row items-center
+                 bg-transparent hover:bg-red-800
+                 text-sm text-red-700 align-middle hover:text-white
+                 py-2 px-4
                  border border-red-700 hover:border-transparent rounded
-                 flex
                  `;
 
   return (

--- a/src/EventContainer.js
+++ b/src/EventContainer.js
@@ -47,6 +47,13 @@ function EventContainer({ events, onDeleteEvent }) {
           <EventList events={sortedEvents} onChooseEvent={choosePage} />
         )}
       </>
+      <>
+        {currentPage === "none" && (
+          <div className="text-blue-700 text-2xl tracking-wider">
+            No events today.
+          </div>
+        )}
+      </>
     </div>
   );
 }
@@ -58,7 +65,7 @@ function EventsMenu({ events, isDisplayed, onChoosePage, chosenEvent }) {
         <div className="flex mb-10 space-x-2">
           <HorizontalMenu>
             <MenuItem callBack={() => onChoosePage()} isSelected={!chosenEvent}>
-              <i className="gg-list transform scale-90 mr-3"></i> Planning
+              <i className="gg-list mr-3"></i> Planning
             </MenuItem>
           </HorizontalMenu>
           <>
@@ -91,13 +98,11 @@ function HorizontalMenu({ children }) {
 }
 
 function MenuItem({ children, isSelected, callBack }) {
+  const style = `flex px-4 pb-2 border-b-4 border-white hover:border-blue-600 cursor-pointer`;
+  const selectedStyle = isSelected ? "border-blue-600" : "";
+
   return (
-    <li
-      className={`flex px-4 pb-2 border-b-4 border-white ${
-        isSelected ? "border-blue-600" : ""
-      } hover:border-blue-600`}
-      onClick={callBack}
-    >
+    <li className={`${style} ${selectedStyle}`} onClick={callBack}>
       {children}
     </li>
   );

--- a/src/EventContainer.js
+++ b/src/EventContainer.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
 import isBetween from "dayjs/plugin/isBetween";
+import { Button } from "./Button";
 dayjs.extend(isBetween);
 
 function EventContainer({ events }) {
@@ -69,19 +70,6 @@ function EventsMenu({ events, isDisplayed, onChoosePage }) {
   );
 }
 
-function EventDetails({ event }) {
-  return (
-    <div className="h-full flex flex-row justify between w-full text-gray-800">
-      <div className="font-bold text-3xl tracking-wider pr-4 border-r-2 border-gray-300">
-        {event.time}
-      </div>
-      <div className="ml-5 flex flex-grow">
-        <div className="flex-grow text-2xl">{event.title}</div>
-      </div>
-    </div>
-  );
-}
-
 function HorizontalMenu({ children, callBack }) {
   return (
     <ul className="bg-white flex flex-row text-sm rounded px-3 pt-3 items-center">
@@ -98,6 +86,24 @@ function MenuItem({ children, callBack }) {
     >
       {children}
     </li>
+  );
+}
+
+function EventDetails({ event, onDeleteEvent }) {
+  return (
+    <div className="flex flex-row justify between w-full p-10 bg-white text-gray-800 rounded-lg">
+      <div className="font-bold text-2xl text-blue-700 tracking-wider pr-4 border-r-2 border-gray-300">
+        {event.time}
+      </div>
+      <div className="ml-5 flex flex-grow">
+        <div className="flex-grow text-2xl">{event.title}</div>
+      </div>
+      <div className="ml-5 justify-end">
+        <DeleteButton callBack={onDeleteEvent}>
+          <i class="gg-trash mr-3"></i> Delete
+        </DeleteButton>
+      </div>
+    </div>
   );
 }
 
@@ -198,5 +204,20 @@ Event.propTypes = {
   event: PropTypes.object.isRequired,
   onChooseEvent: PropTypes.func.isRequired,
 };
+
+function DeleteButton({ children, callBack }) {
+  const outlineStyle = `bg-transparent hover:bg-red-800
+                 text-sm text-red-700 font-semibold hover:text-white
+                 py-3 px-4
+                 border border-red-700 hover:border-transparent rounded
+                 flex
+                 `;
+
+  return (
+    <Button callBack={callBack} css={outlineStyle}>
+      {children}
+    </Button>
+  );
+}
 
 export default EventContainer;

--- a/src/EventForm.js
+++ b/src/EventForm.js
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import { Button, OutlineButton, BlueSubmitButton } from "./Button";
 import { range } from "./utils";
 
-function EventForm({ date, display, onAddEvent, onClose }) {
+function EventForm({ events, date, display, onAddEvent, onClose }) {
   const titleInput = useRef();
 
   const [eventHour, setEventHour] = useState(12);

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -36,12 +36,16 @@ function createYearCalendarCells(year, events) {
         });
       } else {
         const date = new Date(year, month - 1, day, 0, 0, 0, 0);
+        const dailyEvents = events.filter(
+          (event) => event.date === dayjs(date).format("YYYY-MM-DD")
+        );
+
         daysInMonth[day].push({
           month: month,
           day: day,
           hasDate: true,
           date: date,
-          events: events[dayjs(date).format("YYYY-MM-DD")],
+          events: dailyEvents,
         });
       }
     });
@@ -49,23 +53,22 @@ function createYearCalendarCells(year, events) {
   return daysInMonth;
 }
 
-const dummyEvents = {
-  "2020-04-13": [
-    { date: "2020-04-13", time: "11:00", title: "go to the beach" },
-    {
-      date: "2020-04-13",
-      time: "17:00",
-      title: "play FF7 with Ryan and Simon",
-    },
-    {
-      date: "2020-04-13",
-      time: "21:00",
-      title:
-        "Drinks with Natasha and Pepito at the hacienda near the cemetery.",
-    },
-  ],
-  "2020-04-19": [{ date: "2020-04-19", time: "15:00", title: "confinement" }],
-  "2020-05-20": [{ date: "2020-04-20", time: "15:00", title: "poule au pot" }],
-};
+const dummyEvents = [
+  { id: 1, date: "2020-04-13", time: "11:00", title: "go to the beach" },
+  {
+    id: 2,
+    date: "2020-04-13",
+    time: "17:00",
+    title: "play FF7 with Ryan and Simon",
+  },
+  {
+    id: 3,
+    date: "2020-04-13",
+    time: "21:00",
+    title: "Drinks with Natasha and Pepito at the hacienda near the cemetery.",
+  },
+  { id: 4, date: "2020-04-19", time: "15:00", title: "confinement" },
+  { id: 5, date: "2020-05-20", time: "15:00", title: "poule au pot" },
+];
 
 export { createYearCalendarCells, dummyEvents };


### PR DESCRIPTION
Quite a messy PR, I had several ideas in mind when I begun working on adding an events details page but things got quite messy as I went back and forth on design, UI ideas and so on.

Anyway, I think I managed to find a relevant way to style both the events list and the event details page in a meaningful and efficient way.

This all started because I wanted to get rid of the `close` buttons I've used too much on this app.
I read quite a few articles and decided to make sure modals are seldom used in order to make them as relevant as possible.

I sensed that my design was not clear enough and would not work well if I added new features. it was pretty frustrating at the beginning  to re-design (already 😅) the day modal but some dribbble inspo and reading pushed me in the right direction.

Here are the changes I made: 
- changed overall day modal layout
- added an events details page
- allowed people to delete an event
- replaced the close event behavior by a nav menu allowing to navigate between planning and events.
- refactored / moved code to clarify things a bit.

I must admit that right now I think that I miss some point about where things should go. The  Component list is growing fast and some things are probably not where they should be. I keep thinking about it without doing much about it as I think I'll probably learn about it along the way, or later. As time is scarce, speed wins!