### PR TITLE
Make modal accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "dayjs": "^1.8.23",
+    "focus-trap-react": "^6.0.0",
     "momentjs": "^2.0.0",
     "react": "^16.13.1",
     "react-cool-onclickoutside": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dayjs": "^1.8.23",
     "momentjs": "^2.0.0",
     "react": "^16.13.1",
+    "react-cool-onclickoutside": "^1.4.7",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1"
   },

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,13 +1,25 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-function Button({ children, callBack, css = "", value = "", type = "button" }) {
+function Button({
+  children,
+  callBack,
+  css = "",
+  value = "",
+  type = "button",
+  ariaLabel = "",
+  ariaLabelledBy = "",
+  autoFocus = false,
+}) {
   return (
     <button
       onClick={callBack}
-      className={`${css} focus:outline-none`}
+      className={`${css} focus:outline-none focus:shadow-outline`}
       value={value}
       type={type}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      autoFocus={autoFocus}
     >
       {children}
     </button>
@@ -19,20 +31,6 @@ Button.propTypes = {
   children: PropTypes.node.isRequired,
   css: PropTypes.string,
 };
-
-function OutlineButton({ children, callBack }) {
-  const outlineStyle = `bg-transparent hover:bg-blue-800
-                 text-xs text-blue-700 font-semibold hover:text-white
-                 py-1 px-2
-                 border border-blue-700 hover:border-transparent
-                 `;
-
-  return (
-    <Button callBack={callBack} css={outlineStyle}>
-      {children}
-    </Button>
-  );
-}
 
 function BlueButton({ children, callBack }) {
   const blueStyle = `
@@ -75,10 +73,36 @@ function OutlineSubmitButton({ value }) {
   return <SubmitButton value={value} css={outlineStyle} />;
 }
 
+function ModalButton({
+  children,
+  callBack,
+  ariaLabel,
+  ariaLabelledBy,
+  autoFocus,
+}) {
+  const outlineStyle = `bg-transparent hover:bg-blue-800
+                 text-xs text-blue-700 font-semibold hover:text-white
+                 py-1 px-2
+                 border border-blue-700 hover:border-transparent
+                 `;
+
+  return (
+    <Button
+      callBack={callBack}
+      css={outlineStyle}
+      ariaLabel={ariaLabel}
+      ariaLabelledBy={ariaLabelledBy}
+      autoFocus={autoFocus}
+    >
+      {children}
+    </Button>
+  );
+}
+
 export {
   Button,
-  OutlineButton,
   SubmitButton,
+  ModalButton,
   OutlineSubmitButton,
   BlueSubmitButton,
   BlueButton,

--- a/src/EventForm.js
+++ b/src/EventForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
 import dayjs from "dayjs";
-import { Button, OutlineButton, BlueSubmitButton } from "./Button";
+import { Button, ModalButton, BlueSubmitButton } from "./Button";
 import { range } from "./utils";
 
 function EventForm({ events, date, display, onAddEvent, onClose }) {
@@ -72,7 +72,13 @@ function EventForm({ events, date, display, onAddEvent, onClose }) {
             <h3 className="leading-relaxed text-2xl tracking-wider text-blue-700 font-semibold">
               New Event
             </h3>
-            <OutlineButton callBack={close}>✕</OutlineButton>
+            <ModalButton
+              callBack={close}
+              ariaLabel="close form"
+              ariaLabelledBy="close-form"
+            >
+              ✕
+            </ModalButton>
           </div>
           <div className="mt-2">
             <EventLabel>Title</EventLabel>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,11 +1,23 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import ReactDOM from "react-dom";
+import useOnclickOutside from "react-cool-onclickoutside";
 import { ModalButton } from "./Button";
 function Modal({ children, showModal, onCloseModal }) {
+  const modalContent = useRef();
+
+  useOnclickOutside(modalContent, () => {
+    onCloseModal();
+  });
+
   return (
     <>
       {showModal ? (
-        <ModalContent onCloseModal={onCloseModal}>{children}</ModalContent>
+        <ModalContent
+          onCloseModal={onCloseModal}
+          modalContentRef={modalContent}
+        >
+          {children}
+        </ModalContent>
       ) : (
         <React.Fragment />
       )}
@@ -13,7 +25,7 @@ function Modal({ children, showModal, onCloseModal }) {
   );
 }
 
-function ModalContent({ children, onCloseModal }) {
+function ModalContent({ children, onCloseModal, modalContentRef }) {
   const onKeyDown = (event) => {
     if (event.keyCode === 27) {
       onCloseModal();
@@ -29,7 +41,10 @@ function ModalContent({ children, onCloseModal }) {
       tabIndex="-1"
       onKeyDown={onKeyDown}
     >
-      <div className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md">
+      <div
+        ref={modalContentRef}
+        className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md"
+      >
         <div className="w-full flex items-center justify-end flex-wrap p-1">
           <ModalButton
             callBack={() => onCloseModal()}

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import ReactDOM from "react-dom";
+import FocusTrap from "focus-trap-react";
 import useOnclickOutside from "react-cool-onclickoutside";
 import { ModalButton } from "./Button";
+
 function Modal({ children, showModal, onCloseModal }) {
   const modalContent = useRef();
 
@@ -33,34 +35,36 @@ function ModalContent({ children, onCloseModal, modalContentRef }) {
   };
 
   return ReactDOM.createPortal(
-    <aside
-      className="fixed top-0 left-0 w-screen h-screen flex items-center"
-      style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
-      role="dialog"
-      aria-modal="true"
-      tabIndex="-1"
-      onKeyDown={onKeyDown}
-    >
-      <div
-        ref={modalContentRef}
-        className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md"
+    <FocusTrap>
+      <aside
+        className="fixed top-0 left-0 w-screen h-screen flex items-center"
+        style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
+        role="dialog"
+        aria-modal="true"
+        tabIndex="-1"
+        onKeyDown={onKeyDown}
       >
-        <div className="w-full flex items-center justify-end flex-wrap p-1">
-          <ModalButton
-            callBack={() => onCloseModal()}
-            ariaLabel="Close modal"
-            ariaLabelledby="close-modal"
-            autoFocus={true}
-          >
-            ✕
-          </ModalButton>
-        </div>
+        <div
+          ref={modalContentRef}
+          className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md"
+        >
+          <div className="w-full flex items-center justify-end flex-wrap p-1">
+            <ModalButton
+              callBack={() => onCloseModal()}
+              ariaLabel="Close modal"
+              ariaLabelledby="close-modal"
+              autoFocus={true}
+            >
+              ✕
+            </ModalButton>
+          </div>
 
-        <div className="h-full box-border overflow-auto flex flex-col justify-start mx-2 px-1 pt-1 pb-5">
-          {children}
+          <div className="h-full box-border overflow-auto flex flex-col justify-start mx-2 px-1 pt-1 pb-5">
+            {children}
+          </div>
         </div>
-      </div>
-    </aside>,
+      </aside>
+    </FocusTrap>,
     document.body
   );
 }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -14,6 +14,12 @@ function Modal({ children, showModal, onCloseModal }) {
 }
 
 function ModalContent({ children, onCloseModal }) {
+  const onKeyDown = (event) => {
+    if (event.keyCode === 27) {
+      onCloseModal();
+    }
+  };
+
   return ReactDOM.createPortal(
     <aside
       className="fixed top-0 left-0 w-screen h-screen flex items-center"
@@ -21,6 +27,7 @@ function ModalContent({ children, onCloseModal }) {
       role="dialog"
       aria-modal="true"
       tabIndex="-1"
+      onKeyDown={onKeyDown}
     >
       <div className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md">
         <div className="w-full flex items-center justify-end flex-wrap p-1">

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import ReactDOM from "react-dom";
-import { OutlineButton } from "./Button";
-
+import { ModalButton } from "./Button";
 function Modal({ children, showModal, onCloseModal }) {
   return (
     <>
@@ -19,10 +18,20 @@ function ModalContent({ children, onCloseModal }) {
     <aside
       className="fixed top-0 left-0 w-screen h-screen flex items-center"
       style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
+      role="dialog"
+      aria-modal="true"
+      tabIndex="-1"
     >
       <div className="static box-border top-0 right-0 h-screen w-3/4 max-w-3/4 p-2 bg-white border shadow-md">
         <div className="w-full flex items-center justify-end flex-wrap p-1">
-          <OutlineButton callBack={() => onCloseModal()}>✕</OutlineButton>
+          <ModalButton
+            callBack={() => onCloseModal()}
+            ariaLabel="Close modal"
+            ariaLabelledby="close-modal"
+            autoFocus={true}
+          >
+            ✕
+          </ModalButton>
         </div>
 
         <div className="h-full box-border overflow-auto flex flex-col justify-start mx-2 px-1 pt-1 pb-5">
@@ -33,4 +42,5 @@ function ModalContent({ children, onCloseModal }) {
     document.body
   );
 }
+
 export default Modal;


### PR DESCRIPTION
Relied a lot this article to make the modal accessible.

Since I write functional components I had difficulties to allow closing it on outside click. Got to use a specialized component, `react-cool-onclickoutside`. Works like a charm now.

I will have to continue making this calendar accessible.

Closes #16 