### PR TITLE
Limit number of events displayed on month view

### DIFF
--- a/src/EventContext.js
+++ b/src/EventContext.js
@@ -44,37 +44,55 @@ const dummyEvents = {
     {
       id: 8,
       date: "2020-05-22",
-      time: "18:00",
+      time: "15:00",
       title: "Chill at home",
     },
     {
       id: 9,
       date: "2020-05-22",
-      time: "21:00",
+      time: "17:00",
       title: "Double chill at home, netflix night",
     },
     {
       id: 10,
       date: "2020-05-22",
-      time: "22:00",
+      time: "18:00",
       title: "Toilet time",
     },
     {
       id: 11,
       date: "2020-05-22",
-      time: "23:30",
+      time: "19:00",
+      title: "Nap time",
+    },
+    {
+      id: 12,
+      date: "2020-05-22",
+      time: "20:00",
+      title: "Eat",
+    },
+    {
+      id: 13,
+      date: "2020-05-22",
+      time: "21:00",
+      title: "Netflix",
+    },
+    {
+      id: 14,
+      date: "2020-05-22",
+      time: "22:00",
       title: "Should I sleep?",
     },
   ],
   "2020-05-29": [
     {
-      id: 12,
+      id: 15,
       date: "2020-05-29",
       time: "10:00",
       title: "coffee at la pata negra",
     },
     {
-      id: 13,
+      id: 16,
       date: "2020-05-29",
       time: "16:00",
       title: "Another coffee. Love coffee",
@@ -86,7 +104,7 @@ const EventContext = React.createContext();
 
 function EventStore({ children }) {
   const [events, setEvents] = useState(dummyEvents);
-  const [eventID, setEventID] = useState(13);
+  const [eventID, setEventID] = useState(17);
 
   function addEvent(event) {
     setEventID(eventID + 1);

--- a/src/MonthView.js
+++ b/src/MonthView.js
@@ -9,8 +9,9 @@ import { EventContext } from "./EventContext";
 
 function MonthView({ startOfMonth }) {
   const { events } = useContext(EventContext);
-  const [maxItemHeight, setMaxItemHeight] = useState(0);
   const monthDaysContainerRef = useRef();
+  const [maxItemHeight, setMaxItemHeight] = useState(0);
+  const [maxNumberOfEvents, setMaxNumberOfEvents] = useState(0);
 
   const daysInView = monthViewDays(startOfMonth, events);
   const currentMonth = dayjs(startOfMonth).month();
@@ -24,14 +25,17 @@ function MonthView({ startOfMonth }) {
     "Sunday",
   ];
 
+  const daysListSize = Object.keys(daysInView).length;
+
   useEffect(() => {
-    const maxHeight =
-      monthDaysContainerRef.current.offsetHeight /
-      (Object.keys(daysInView).length / 7);
-    setMaxItemHeight(maxHeight);
-    console.log(maxHeight);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [startOfMonth]);
+    const maxHeight = Math.round(
+      monthDaysContainerRef.current.offsetHeight / (daysListSize / 7)
+    );
+    setMaxItemHeight((x) => maxHeight);
+    const eventHeight = 22; // size of an event. Should be enough to define the max number of events to displey each day.
+    const maxEventsSize = Math.floor(maxHeight / eventHeight) - 1;
+    setMaxNumberOfEvents((x) => maxEventsSize);
+  }, [startOfMonth, daysListSize]);
 
   return (
     <div className="flex flex-col flex-grow h-full border-t border-gray-500">
@@ -55,6 +59,7 @@ function MonthView({ startOfMonth }) {
             month={currentMonth}
             events={daysInView[date]}
             maxHeight={maxItemHeight}
+            maxNumberOfEvents={maxNumberOfEvents}
             key={date}
           />
         ))}

--- a/src/MonthView.js
+++ b/src/MonthView.js
@@ -72,7 +72,7 @@ MonthView.propTypes = exact({
   startOfMonth: PropTypes.instanceOf(Date).isRequired,
 });
 
-function MonthDay({ date, month, events, maxHeight }) {
+function MonthDay({ date, month, events, maxHeight, maxNumberOfEvents }) {
   const [showModal, setShowModal] = useState(false);
   const [contentHeight, setContentHeight] = useState(0);
   const titleRef = useRef();
@@ -116,8 +116,8 @@ function MonthDay({ date, month, events, maxHeight }) {
           style={{ height: `${contentHeight}px` }}
         >
           {events &&
-            events.map((event) => (
-              <li className="truncate">
+            events.slice(0, maxNumberOfEvents).map((event) => (
+              <li className="truncate" key={event.id}>
                 {event.time} {event.title}
               </li>
             ))}
@@ -134,6 +134,7 @@ MonthDay.propTypes = exact({
   month: PropTypes.string.isRequired,
   events: PropTypes.array.isRequired,
   maxHeight: PropTypes.number.isRequired,
+  maxNumberOfEvents: PropTypes.number.isRequired,
 });
 
 export default MonthView;

--- a/src/MonthView.js
+++ b/src/MonthView.js
@@ -76,8 +76,12 @@ function MonthDay({ date, month, events, maxHeight, maxNumberOfEvents }) {
   const [showModal, setShowModal] = useState(false);
   const [contentHeight, setContentHeight] = useState(0);
   const titleRef = useRef();
-
   const monthDay = dayjs(date).date();
+
+  const remainingEventsNumber =
+    events && maxNumberOfEvents < events.length
+      ? events.length - maxNumberOfEvents
+      : undefined;
 
   const chooseStyle = () => {
     const today = dayjs().startOf("day");
@@ -105,7 +109,7 @@ function MonthDay({ date, month, events, maxHeight, maxNumberOfEvents }) {
   return (
     <>
       <div
-        className={`${currentStyle} p-2  border-b border-b-500 cursor-pointer`}
+        className={`${currentStyle} relative p-2 border-b border-b-500 cursor-pointer`}
         onClick={() => setShowModal(true)}
       >
         <div className={`text-md font-semibold`} ref={titleRef}>
@@ -122,6 +126,10 @@ function MonthDay({ date, month, events, maxHeight, maxNumberOfEvents }) {
               </li>
             ))}
         </ul>
+        <RemainingEventsNumber
+          remainingEventsNumber={remainingEventsNumber}
+          isShown={!!remainingEventsNumber}
+        />
       </div>
       <Modal showModal={showModal} onCloseModal={closeModal}>
         <DayModal date={date} events={events} />
@@ -135,6 +143,23 @@ MonthDay.propTypes = exact({
   events: PropTypes.array.isRequired,
   maxHeight: PropTypes.number.isRequired,
   maxNumberOfEvents: PropTypes.number.isRequired,
+});
+
+function RemainingEventsNumber({ remainingEventsNumber, isShown }) {
+  return (
+    <>
+      {isShown && (
+        <div className="absolute bottom-0 left-0 flex w-full justify-end text-xs font-semibold text-gray-600 py-1 px-2">
+          + {remainingEventsNumber}
+        </div>
+      )}
+    </>
+  );
+}
+
+RemainingEventsNumber.propTypes = exact({
+  remainingEventsNumber: PropTypes.number,
+  isShown: PropTypes.bool.isRequired,
 });
 
 export default MonthView;


### PR DESCRIPTION
Quite a small PR, but I struggled to use `useEffect` correctly.

`useEffect` asks for dependencies. I gave it an object with many keys as a dependency and things went quite slow.

I solved this problem by extracting the calculation I made to a variable outside useEffect, then things went way faster.
